### PR TITLE
ci: bump versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,9 +5,9 @@ on: [push, pull_request]
 jobs:
   luacheck:
     name: Luacheck
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Prepare
         run: |
@@ -20,10 +20,10 @@ jobs:
 
   stylua:
     name: Stylua
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: JohnnyMorganz/stylua-action@v3
+      - uses: actions/checkout@v4
+      - uses: JohnnyMorganz/stylua-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,19 +10,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             rev: v0.10.4/nvim-linux-x86_64.tar.gz
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             rev: v0.9.0/nvim-linux64.tar.gz
-          - os: macos-12
+          - os: macos-13
             rev: v0.10.4/nvim-macos-x86_64.tar.gz
-          - os: macos-12
+          - os: macos-13
             rev: v0.9.0/nvim-macos.tar.gz
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: date +%F > todays-date
       - name: Restore from todays cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: _neovim
           key: ${{ runner.os }}-${{ matrix.rev }}-${{ hashFiles('todays-date') }}


### PR DESCRIPTION
Upgrade to:
- ubuntu-22.04 -> ubuntu-latest
- macos-12 -> macos-13
- actions/checkout@v3 -> actions/checkout@v4
- actions/cache@v3 -> actions/cache@v4